### PR TITLE
[WIP] Functionality for adding external domain to the site

### DIFF
--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -4,24 +4,21 @@ provider "aws" {
 
 provider "aws" {
   region = "us-east-1"
-  alias = "certificate_provider"
+  alias  = "certificate_provider"
 }
 
-data "aws_vpc" "main" {
-  default = true
-}
-
-data "aws_subnet_ids" "main" {
-  vpc_id = data.aws_vpc.main.id
+resource "aws_route53_zone" "main" {
+  name = "example.com"
 }
 
 module "static-example" {
-  source           = "../../"
+  source = "../../"
   providers = {
     aws.certificate_provider = aws.certificate_provider
   }
-  name_prefix      = "static-example"
-  hosted_zone_name = "example.com"
-  site_name        = "static-example.example.com"
+  name_prefix = "static-example"
+  domain_zones = {
+    "static-example.example.com" = aws_route53_zone.main.id
+  }
 }
 

--- a/examples/default/versions.tf
+++ b/examples/default/versions.tf
@@ -1,4 +1,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = ">= 2.65.0"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
     for opt in aws_acm_certificate.cert_website.domain_validation_options : opt.domain_name => merge(opt, {
       # NOTE: When `domain_validation_options` references a domain that has been removed from `var.domain_zones`
       # `lookup` defaults to using a value we know exists
-      zone_id = lookup(local.all_domains, opt.domain_name, keys(local.all_domains)[0]).zone_id
+      zone_id = lookup(local.all_domains, opt.domain_name, var.domain_name).zone_id
     })
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,14 +9,22 @@ provider "aws" {
 data "aws_caller_identity" "current-account" {}
 
 locals {
-  all_domains = { for obj in concat([var.domain_name], var.subject_alternative_names) : obj.name => obj }
-  validation_options_by_domain_name = {
-    for opt in aws_acm_certificate.cert_website.domain_validation_options : opt.domain_name => merge(opt, {
-      # NOTE: When `domain_validation_options` references a domain that has been removed from `var.domain_zones`
-      # `lookup` defaults to using a value we know exists
-      zone_id = lookup(local.all_domains, opt.domain_name, var.domain_name).zone_id
+  validation_options_by_domain_name = { for opt in aws_acm_certificate.cert_website.domain_validation_options : opt.domain_name => opt }
+  all_domains_static                = { for obj in concat([var.domain_name], var.subject_alternative_names) : obj.name => obj }
+  all_domains_dynamic = { for name, v in local.all_domains_static : name => merge(v, {
+    /*
+    // NOTE: `domain_validation_options` may reference stale data due to issues with the AWS provider,
+    // so we default to a known value if this is the case.
+    */
+    validation_options = lookup(local.validation_options_by_domain_name, name, values(local.validation_options_by_domain_name)[0])
+    zone_id            = data.aws_route53_zone.zone[name].id
     })
   }
+}
+
+data "aws_route53_zone" "zone" {
+  for_each = local.all_domains_static
+  name     = each.value.zone
 }
 
 resource "aws_acm_certificate" "cert_website" {
@@ -32,13 +40,12 @@ resource "aws_acm_certificate" "cert_website" {
 }
 
 resource "aws_route53_record" "cert_website_validation" {
-  # NOTE: When `domain_validation_options` is not up-to-date, `lookup` will default to values we know exists
   depends_on      = [aws_acm_certificate.cert_website]
-  for_each        = local.all_domains
-  name            = lookup(local.validation_options_by_domain_name, each.key, values(local.validation_options_by_domain_name)[0]).resource_record_name
-  type            = lookup(local.validation_options_by_domain_name, each.key, values(local.validation_options_by_domain_name)[0]).resource_record_type
-  zone_id         = lookup(local.validation_options_by_domain_name, each.key, values(local.validation_options_by_domain_name)[0]).zone_id
-  records         = [lookup(local.validation_options_by_domain_name, each.key, values(local.validation_options_by_domain_name)[0]).resource_record_value]
+  for_each        = local.all_domains_static
+  name            = local.all_domains_dynamic[each.key].validation_options.resource_record_name
+  type            = local.all_domains_dynamic[each.key].validation_options.resource_record_type
+  records         = [local.all_domains_dynamic[each.key].validation_options.resource_record_value]
+  zone_id         = local.all_domains_dynamic[each.key].zone_id
   ttl             = 60
   allow_overwrite = true
 }
@@ -97,7 +104,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   enabled             = true
   is_ipv6_enabled     = true
   default_root_object = "index.html"
-  aliases             = sort(keys(local.all_domains))
+  aliases             = sort(keys(local.all_domains_static))
 
   custom_error_response {
     error_code         = 404
@@ -152,10 +159,10 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 }
 
 resource "aws_route53_record" "www_a" {
-  for_each = local.all_domains
+  for_each = local.all_domains_static
   name     = "${each.key}."
   type     = "A"
-  zone_id  = each.value.zone_id
+  zone_id  = data.aws_route53_zone.zone[each.key].id
   alias {
     name                   = aws_cloudfront_distribution.s3_distribution.domain_name
     zone_id                = aws_cloudfront_distribution.s3_distribution.hosted_zone_id

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ provider "aws" {
 data "aws_caller_identity" "current-account" {}
 
 locals {
-  all_domains = { for obj in concat([var.domain_name], var.subject_alternative_names) : obj.domain => obj }
+  all_domains = { for obj in concat([var.domain_name], var.subject_alternative_names) : obj.name => obj }
   validation_options_by_domain_name = {
     for opt in aws_acm_certificate.cert_website.domain_validation_options : opt.domain_name => merge(opt, {
       # NOTE: When `domain_validation_options` references a domain that has been removed from `var.domain_zones`
@@ -20,10 +20,10 @@ locals {
 }
 
 resource "aws_acm_certificate" "cert_website" {
-  domain_name               = var.domain_name["domain"]
+  domain_name               = var.domain_name.name
   validation_method         = "DNS"
   provider                  = aws.certificate_provider
-  subject_alternative_names = [for obj in var.subject_alternative_names : obj["domain"]]
+  subject_alternative_names = [for obj in var.subject_alternative_names : obj.name]
   tags                      = var.tags
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,10 @@ variable "website_bucket" {
   type        = string
   default     = ""
 }
+
+variable "external_domain" {
+  description = "An external domain to access the site from"
+  default     = ""
+  type        = string
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "website_bucket" {
 }
 
 variable "external_domain" {
-  description = "An external domain to access the site from"
+  description = "(Optional) An external domain to access the site from (e.g. `<app>.vy.no`)"
   default     = ""
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,12 +19,12 @@ variable "tags" {
 }
 
 variable "domain_name" {
-  description = "A map containing a domain and its associated hosted zone ID. The domain will be associated with the CloudFront distribution and ACM certificate."
+  description = "A map containing a domain and name of the associated hosted zone. The domain will be associated with the CloudFront distribution and ACM certificate."
   type        = map(string)
 }
 
 variable "subject_alternative_names" {
-  description = "A list of maps containing domains and their associated hosted zone ID. The domains will be associated with the CloudFront distribution and ACM certificate."
+  description = "A list of maps containing domains and names of their associated hosted zones. The domains will be associated with the CloudFront distribution and ACM certificate."
   type        = list(map(string))
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,9 +18,14 @@ variable "tags" {
   default     = {}
 }
 
-variable "domain_zones" {
-  description = "A map of domains and their associated hosted zone ID. The domains will be associated with the CloudFront distribution and ACM certificate."
+variable "domain_name" {
+  description = "A map containing a domain and its associated hosted zone ID. The domain will be associated with the CloudFront distribution and ACM certificate."
   type        = map(string)
+}
+
+variable "subject_alternative_names" {
+  description = "A list of maps containing domains and their associated hosted zone ID. The domains will be associated with the CloudFront distribution and ACM certificate."
+  type        = list(map(string))
 }
 
 variable "use_external_bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,11 +6,6 @@ variable "name_prefix" {
   type        = string
 }
 
-variable "hosted_zone_name" {
-  description = "The name of the hosted zone in which to register this site"
-  type        = string
-}
-
 variable "bucket_versioning" {
   description = "(Optional) Enable versioning. Once you version-enable a bucket, it can never return to an unversioned state. You can, however, suspend versioning on that bucket."
   type        = bool
@@ -23,9 +18,9 @@ variable "tags" {
   default     = {}
 }
 
-variable "site_name" {
-  description = "The name of the certificate and address for the site"
-  type        = string
+variable "domain_zones" {
+  description = "A map of domains and their associated hosted zone ID. The domains will be associated with the CloudFront distribution and ACM certificate."
+  type        = map(string)
 }
 
 variable "use_external_bucket" {
@@ -40,9 +35,8 @@ variable "website_bucket" {
   default     = ""
 }
 
-variable "external_domain" {
-  description = "(Optional) An external domain to access the site from (e.g. `<app>.vy.no`)"
-  default     = ""
+variable "certificate_validation_timeout" {
+  description = "(Optional) How long to wait for the certificate to be issued."
   type        = string
+  default     = "45m"
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,7 @@
-
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = ">= 2.65.0"
+  }
 }


### PR DESCRIPTION
Adds support for associating multiple domain names with the CloudFront distribution and ACM certificate. The changes introduced are **not** backwards-compatible.

Due to issues with the AWS provider, issues arise when you add/remove domains after the code has already been applied (the domains in `aws_acm_certificate.cert_website.domain_validation_options` will not be up-to-date when applying, so an Index/Element error will be raised). A temporary fix is to use Terraform's `lookup` method to fall back to known values if the `domain_validation_options` are not up-to-date. The fallback values should actually result in errors if used, but in practice the `domain_validation_options` are always up-to-date during the apply.  

There are many issues with the `aws_acm_certificate` resource, and it is due for a rewrite in v3.0 (see issue https://github.com/terraform-providers/terraform-provider-aws/issues/13053).

Relevant issues:
- **https://github.com/terraform-providers/terraform-provider-aws/issues/9840**
- https://github.com/terraform-providers/terraform-provider-aws/issues/9596
- https://github.com/terraform-providers/terraform-provider-aws/issues/9589