### PR TITLE
KT-129: 60m timeout on aws_acm_certificate_validation. (The default t…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,10 @@ resource "aws_acm_certificate_validation" "main" {
   certificate_arn         = aws_acm_certificate.cert_website.arn
   validation_record_fqdns = [for record in aws_route53_record.cert_website_validation : record.fqdn]
   provider                = aws.certificate_provider
+
+  timeouts {
+    create = "60m"
+  }
 }
 
 data "aws_s3_bucket" "website_bucket" {


### PR DESCRIPTION
…imeout (45m) is not enough, as retries are done at 20m and 50m.)